### PR TITLE
add SensorBase class as base class for sensors

### DIFF
--- a/urdf_model/include/urdf_model/model.h
+++ b/urdf_model/include/urdf_model/model.h
@@ -42,6 +42,7 @@
 #include <boost/function.hpp>
 #include <urdf_model/link.h>
 #include <urdf_exception/exception.h>
+#include <urdf_sensor/sensor.h>
 
 namespace urdf {
 
@@ -197,7 +198,7 @@ public:
   /// \brief The root is always a link (the parent of the tree describing the robot)
   boost::shared_ptr<Link> root_link_;
 
-
+  std::map<std::string, boost::shared_ptr<Sensor> > sensors_;
 
 };
 

--- a/urdf_sensor/include/urdf_sensor/sensor.h
+++ b/urdf_sensor/include/urdf_sensor/sensor.h
@@ -72,10 +72,18 @@
 
 namespace urdf{
 
-class VisualSensor
+class SensorBase {
+public:
+  enum {VISUAL, FORCE, TACTILE, IMU, GYRO, ACCELERATION, GPS} sensor_type;
+  virtual ~SensorBase(void)
+  {
+  }
+};
+
+class VisualSensor : public SensorBase
 {
 public:
-  enum {CAMERA, RAY} type;
+  enum {CAMERA, RAY, DEPTH} type;
   virtual ~VisualSensor(void)
   {
   }
@@ -148,8 +156,7 @@ public:
   Pose origin;
 
   /// sensor
-  boost::shared_ptr<VisualSensor> sensor;
-
+  boost::shared_ptr<SensorBase> sensor;
 
   /// Parent link element name.  A pointer is stored in parent_link_.
   std::string parent_link_name;


### PR DESCRIPTION
I would like to use sensor descriptions on urdf_model.
So, I added SensorBase class as base class for sensors including VisionSensor.
This patch is compatible with https://github.com/ros/urdfdom/pull/28
