### PR TITLE
Fixes from sdformat

### DIFF
--- a/urdf_model/include/urdf_model/color.h
+++ b/urdf_model/include/urdf_model/color.h
@@ -72,9 +72,9 @@ public:
       {
         try
         {
-          rgba.push_back(boost::lexical_cast<double>(pieces[i].c_str()));
+          rgba.push_back(boost::lexical_cast<float>(pieces[i].c_str()));
         }
-        catch (boost::bad_lexical_cast &e)
+        catch (boost::bad_lexical_cast &/*e*/)
         {
           return false;
         }

--- a/urdf_model/include/urdf_model/pose.h
+++ b/urdf_model/include/urdf_model/pose.h
@@ -68,7 +68,7 @@ public:
         try {
           xyz.push_back(boost::lexical_cast<double>(pieces[i].c_str()));
         }
-        catch (boost::bad_lexical_cast &e) {
+        catch (boost::bad_lexical_cast &/*e*/) {
           throw ParseError("Unable to parse component [" + pieces[i] + "] to a double (while parsing a vector value)");
         }
       }

--- a/urdf_model/include/urdf_model/pose.h
+++ b/urdf_model/include/urdf_model/pose.h
@@ -40,7 +40,7 @@
 #include <string>
 #include <sstream>
 #include <vector>
-#include <math.h>
+#include <cmath>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <urdf_exception/exception.h>

--- a/urdf_world/include/urdf_world/world.h
+++ b/urdf_world/include/urdf_world/world.h
@@ -35,7 +35,7 @@
 /* Author: John Hsu */
 
 /* encapsulates components in a world
-   see http://ros.org/wiki/usdf/XML/urdf_world and
+   see http://ros.org/wiki/usdf/XML/urdf_world
    for details
 */
 /* example world XML


### PR DESCRIPTION
We have a fork of urdfdom in sdformat that we use on platforms that don't have a system urdfdom package available. We have been working on Windows support for sdformat and made one fix (double -> float), include `cmath` instead of `math.h` (since this is C++, not C), and some other changes that reduce the number of compiler warnings about unused catch variables.

@nkoenig