### PR TITLE
[joint] reset `JointMimic` pointer on clear

### DIFF
--- a/urdf_model/include/urdf_model/joint.h
+++ b/urdf_model/include/urdf_model/joint.h
@@ -220,6 +220,7 @@ public:
     this->limits.reset();
     this->safety.reset();
     this->calibration.reset();
+    this->mimic.reset();
     this->type = UNKNOWN;
   };
 };


### PR DESCRIPTION
For consistency with other attributes.