### PR TITLE
sensor.h: remove boost smart pointer includes

### DIFF
--- a/urdf_sensor/include/urdf_sensor/sensor.h
+++ b/urdf_sensor/include/urdf_sensor/sensor.h
@@ -64,8 +64,6 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
 #include "urdf_model/pose.h"
 #include "urdf_model/joint.h"
 #include "urdf_model/link.h"


### PR DESCRIPTION
Sorry I missed two of the boost include statements in `sensor.h` in #13 