### PR TITLE
Add Capsule primitives

### DIFF
--- a/urdf_model/include/urdf_model/link.h
+++ b/urdf_model/include/urdf_model/link.h
@@ -50,7 +50,7 @@ namespace urdf{
 class Geometry
 {
 public:
-  enum {SPHERE, BOX, CYLINDER, MESH} type;
+  enum {SPHERE, BOX, CYLINDER, CAPSULE, MESH} type;
 
   virtual ~Geometry(void)
   {
@@ -85,6 +85,20 @@ class Cylinder : public Geometry
 {
 public:
   Cylinder() { this->clear(); type = CYLINDER; };
+  double length;
+  double radius;
+
+  void clear()
+  {
+    length = 0;
+    radius = 0;
+  };
+};
+
+class Capsule : public Geometry
+{
+public:
+  Capsule() { this->clear(); type = CAPSULE; };
   double length;
   double radius;
 


### PR DESCRIPTION
Collision checking with capsules is faster than with cylinder. As FCL has this primitives, I guess it shouldn't be a problem to add them in the URDF format ?
I have made changes in `urdfdom` packages as well.
