### PR TITLE
cleanup declaration of ModelInterface's SharedPtrs

### DIFF
--- a/include/urdf_model/types.h
+++ b/include/urdf_model/types.h
@@ -67,6 +67,8 @@ URDF_TYPEDEF_CLASS_POINTER(Mesh);
 URDF_TYPEDEF_CLASS_POINTER(Sphere);
 URDF_TYPEDEF_CLASS_POINTER(Visual);
 
+URDF_TYPEDEF_CLASS_POINTER(ModelInterface);
+
 // create *_pointer_cast functions in urdf namespace
 template<class T, class U>
 std::shared_ptr<T> const_pointer_cast(std::shared_ptr<U> const & r)

--- a/include/urdf_world/types.h
+++ b/include/urdf_world/types.h
@@ -37,16 +37,7 @@
 #ifndef URDF_WORLD_TYPES_H
 #define URDF_WORLD_TYPES_H
 
-#include <memory>
-
-
-namespace urdf{
-
-class ModelInterface;
-
-// typedef shared pointers
-typedef std::shared_ptr<ModelInterface> ModelInterfaceSharedPtr;
-
-}
+#warning urdf_world/types.h is deprecated. Please use urdf_model/types.h instead.
+#include <urdf_model/types.h>
 
 #endif

--- a/include/urdf_world/world.h
+++ b/include/urdf_world/world.h
@@ -74,10 +74,9 @@
 #include <vector>
 #include <map>
 
-#include "urdf_model/model.h"
+#include "urdf_model/types.h"
 #include "urdf_model/pose.h"
 #include "urdf_model/twist.h"
-#include "urdf_world/types.h"
 
 namespace urdf{
 
@@ -107,4 +106,3 @@ public:
 }
 
 #endif
-


### PR DESCRIPTION
I propose to declare the `SharedPtrs` for `ModelInterface` together with all other model-related types in `urdf_model/types.h` instead of `urdf_world/types.h`.

Currently, even after having included `urdf_model/model.h`, one also needs to include `urdf_world/types.h` to get the related SharedPtr definitions.

With this PR, it suffices to include `urdf_model/types.h` to get all declarations or to include `urdf_model/model.h` for all declarations and definition of `ModelInterface`.
