### PR TITLE
always define M_PI

### DIFF
--- a/urdf_model/include/urdf_model/pose.h
+++ b/urdf_model/include/urdf_model/pose.h
@@ -45,7 +45,7 @@
 #endif
 #endif
 
-#include <cmath>
+#include <math.h>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/urdf_model/include/urdf_model/pose.h
+++ b/urdf_model/include/urdf_model/pose.h
@@ -45,7 +45,7 @@
 #endif
 #endif
 
-#include <math.h>
+#include <cmath>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/urdf_model/include/urdf_model/pose.h
+++ b/urdf_model/include/urdf_model/pose.h
@@ -54,6 +54,10 @@
 #include <urdf_exception/exception.h>
 #include <urdf_model/utils.h>
 
+#ifndef M_PI
+const double M_PI = 3.14159265;
+#endif
+
 namespace urdf{
 
 class Vector3


### PR DESCRIPTION
I changed `<cmath>` to `<math.h>` in order to consistently activate the `_USE_MATH_DEFINES` symbols such as `M_PI` when compiling a complete windows stack workspace, such as ROS2.0

The reason for opening this PR is that when building the ROS2.0 workspace on Windows, this package fails with `M_PI` symbols not being defined. The problem is that `cmath` different from `math.h` does only once check whether the math symbols are activated. If something higher in the pipeline overwrites these definitions, `cmath` gets built wo/ these symbols.

see [this stackoverflow thread](http://stackoverflow.com/questions/6563810/m-pi-works-with-math-h-but-not-with-cmath-in-visual-studio) for more information.