### PR TITLE
Switch from TinyXML to TinyXML2

### DIFF
--- a/urdf_world/include/urdf_world/world.h
+++ b/urdf_world/include/urdf_world/world.h
@@ -73,7 +73,7 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <tinyxml.h>
+#include <tinyxml2.h>
 
 #include "urdf_model/model.h"
 #include "urdf_model/pose.h"
@@ -100,7 +100,7 @@ public:
 
   std::vector<Entity> models;
 
-  void initXml(TiXmlElement* config);
+  void initXml(tinyxml2::XMLElement* config);
 
   void clear()
   {


### PR DESCRIPTION
The library TinyXML is considered to be unmaintained and since all future development is focused on TinyXML2 this patch updates urdfdom_headers to use TinyXML2.