### PR TITLE
Add a package.xml for ROS 2.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>urdfdom-headers</name>
+  <version>1.0.0</version>
+  <description>
+    C++ headers for URDF.
+  </description>
+  <maintainer email="steven@openrobotics.org">Steven! Ragnarök</maintainer>
+  <license>BSD</license>
+
+  <url type="website">http://ros.org/wiki/urdf</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>boost</depend>
+  <depend>console_bridge</depend>
+  <depend>tinyxml</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
In order to keep the cmake project name `urdfdom_headers` while changing the package dependency key to `urdfdom-headers`, which will eventually allow us to switch to upstream urdfdom-headers when it is available on target platforms without changing dependent packages then, we need to place a package.xml file in the source repository rather than patching it in at release-time.

Must wait for https://github.com/ament/ament_package/pull/51