### PR TITLE
world.h: remove initXml function, tinyxml include

### DIFF
--- a/urdf_world/include/urdf_world/world.h
+++ b/urdf_world/include/urdf_world/world.h
@@ -73,7 +73,6 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <tinyxml.h>
 
 #include "urdf_model/model.h"
 #include "urdf_model/pose.h"
@@ -100,6 +99,7 @@ public:
 
   std::vector<Entity> models;
 
+  class TiXmlElement;
   void initXml(TiXmlElement* config);
 
   void clear()

--- a/urdf_world/include/urdf_world/world.h
+++ b/urdf_world/include/urdf_world/world.h
@@ -67,8 +67,8 @@
 
 */
 
-#ifndef USDF_STATE_H
-#define USDF_STATE_H
+#ifndef URDF_WORLD_H
+#define URDF_WORLD_H
 
 #include <string>
 #include <vector>
@@ -98,9 +98,6 @@ public:
   std::string name;
 
   std::vector<Entity> models;
-
-  class TiXmlElement;
-  void initXml(TiXmlElement* config);
 
   void clear()
   {


### PR DESCRIPTION
The urdf::World::initXml function is never implemented
and causes an unnecessary tinyxml dependency.
So remove that function and the tinyxml include.