### PR TITLE
Use stringstream instead of stod to work around locale issues.

### DIFF
--- a/urdf_model/include/urdf_model/pose.h
+++ b/urdf_model/include/urdf_model/pose.h
@@ -68,6 +68,7 @@ public:
       if (pieces[i] != ""){
         double piece;
         std::stringstream ss;
+        ss.imbue(std::locale::classic());
 
         ss << pieces[i];
         ss >> piece;

--- a/urdf_model/include/urdf_model/pose.h
+++ b/urdf_model/include/urdf_model/pose.h
@@ -66,18 +66,11 @@ public:
     urdf::split_string( pieces, vector_str, " ");
     for (unsigned int i = 0; i < pieces.size(); ++i){
       if (pieces[i] != ""){
-        double piece;
-        std::stringstream ss;
-        ss.imbue(std::locale::classic());
-
-        ss << pieces[i];
-        ss >> piece;
-
-        if (ss.fail() || !ss.eof()) {
+        try {
+          xyz.push_back(strToDouble(pieces[i].c_str()));
+        } catch(std::runtime_error &) {
           throw ParseError("Unable to parse component [" + pieces[i] + "] to a double (while parsing a vector value)");
         }
-
-        xyz.push_back(piece);
       }
     }
 

--- a/urdf_model/include/urdf_model/pose.h
+++ b/urdf_model/include/urdf_model/pose.h
@@ -66,15 +66,17 @@ public:
     urdf::split_string( pieces, vector_str, " ");
     for (unsigned int i = 0; i < pieces.size(); ++i){
       if (pieces[i] != ""){
-        try {
-          xyz.push_back(std::stod(pieces[i]));
-        }
-        catch (std::invalid_argument &/*e*/) {
+        double piece;
+        std::stringstream ss;
+
+        ss << pieces[i];
+        ss >> piece;
+
+        if (ss.fail() || !ss.eof()) {
           throw ParseError("Unable to parse component [" + pieces[i] + "] to a double (while parsing a vector value)");
         }
-        catch (std::out_of_range &/*e*/) {
-          throw ParseError("Unable to parse component [" + pieces[i] + "] to a double, out of range (while parsing a vector value)");
-        }
+
+        xyz.push_back(piece);
       }
     }
 

--- a/urdf_model/include/urdf_model/utils.h
+++ b/urdf_model/include/urdf_model/utils.h
@@ -62,6 +62,28 @@ void split_string(std::vector<std::string> &result,
   }
 }
 
+// This is a locale-safe version of string-to-double, which is suprisingly
+// difficult to do correctly.  This function ensures that the C locale is used
+// for parsing, as that matches up with what the XSD for double specifies.
+// On success, the double is returned; on failure, a std::runtime_error is
+// thrown.
+static inline double strToDouble(const char *in)
+{
+  std::stringstream ss;
+  ss.imbue(std::locale::classic());
+
+  ss << in;
+
+  double out;
+  ss >> out;
+
+  if (ss.fail() || !ss.eof()) {
+    throw std::runtime_error("");
+  }
+
+  return out;
+}
+
 }
 
 #endif

--- a/urdf_model/include/urdf_model/utils.h
+++ b/urdf_model/include/urdf_model/utils.h
@@ -81,7 +81,7 @@ static inline double strToDouble(const char *in)
   ss >> out;
 
   if (ss.fail() || !ss.eof()) {
-    throw std::runtime_error("");
+    throw std::runtime_error("Failed converting string to double");
   }
 
   return out;

--- a/urdf_model/include/urdf_model/utils.h
+++ b/urdf_model/include/urdf_model/utils.h
@@ -37,6 +37,9 @@
 #ifndef URDF_INTERFACE_UTILS_H
 #define URDF_INTERFACE_UTILS_H
 
+#include <locale>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
The URDF schema (https://github.com/ros/urdfdom/blob/master/xsd/urdf.xsd#L47) defines doubles in URDF as xs:double. Looking at the XSD document at https://www.w3.org/TR/xmlschema-2/#double, it says that the mantissa for a double is represented as a "decimal" number. And looking at the XSD document at https://www.w3.org/TR/xmlschema-2/#decimal, a decimal number is a "finite-length sequence of decimal digits (#x30-#x39) separated by a period as a decimal indicator". Thus, the locale should have no effect on how the document is parsed, and using std::stod is incorrect.  This patch switches the Vector3 class to using the stream operator, which seems to ignore locale.

fixes #41 

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>