### PR TITLE
use helper function strToDouble for locale independent parsing of colors

### DIFF
--- a/urdf_model/include/urdf_model/color.h
+++ b/urdf_model/include/urdf_model/color.h
@@ -73,7 +73,10 @@ public:
       {
         try
         {
-          rgba.push_back(strToDouble(pieces[i].c_str()));
+          double piece = strToDouble(pieces[i].c_str());
+          if ((piece < 0) || (piece > 1))
+            throw ParseError("Component [" + pieces[i] + "] is outside the valid range for colors [0, 1]");
+          rgba.push_back(piece);
         }
         catch (std::runtime_error &/*e*/) {
           throw ParseError("Unable to parse component [" + pieces[i] + "] to a double (while parsing a color value)");

--- a/urdf_model/include/urdf_model/color.h
+++ b/urdf_model/include/urdf_model/color.h
@@ -73,13 +73,10 @@ public:
       {
         try
         {
-          rgba.push_back(std::stof(pieces[i]));
+          rgba.push_back(strToDouble(pieces[i].c_str()));
         }
-        catch (std::invalid_argument &/*e*/) {
-          return false;
-        }
-        catch (std::out_of_range &/*e*/) {
-          return false;
+        catch (std::runtime_error &/*e*/) {
+          throw ParseError("Unable to parse component [" + pieces[i] + "] to a double (while parsing a color value)");
         }
       }
     }


### PR DESCRIPTION
This commit fixes #46 by using strToDouble instead of the locale dependent std::stof