### PR TITLE
Add missing include to exception.h

### DIFF
--- a/urdf_model/include/urdf_model/color.h
+++ b/urdf_model/include/urdf_model/color.h
@@ -43,6 +43,7 @@
 #include <math.h>
 
 #include <urdf_model/utils.h>
+#include <urdf_exception/exception.h>
 
 namespace urdf
 {


### PR DESCRIPTION
Otherwise dependent packages fail to find the function when compiling.