### PR TITLE
Add ConvexHull Geometry Type

### DIFF
--- a/urdf_model/include/urdf_model/link.h
+++ b/urdf_model/include/urdf_model/link.h
@@ -50,7 +50,7 @@ namespace urdf{
 class Geometry
 {
 public:
-  enum {SPHERE, BOX, CYLINDER, MESH} type;
+  enum {SPHERE, BOX, CYLINDER, MESH, CONVEX_HULL} type;
 
   virtual ~Geometry(void)
   {
@@ -99,6 +99,23 @@ class Mesh : public Geometry
 {
 public:
   Mesh() { this->clear(); type = MESH; };
+  std::string filename;
+  Vector3 scale;
+
+  void clear()
+  {
+    filename.clear();
+    // default scale
+    scale.x = 1;
+    scale.y = 1;
+    scale.z = 1;
+  };
+};
+
+class ConvexHull : public Geometry
+{
+public:
+  ConvexHull() { this->clear(); type = CONVEX_HULL; };
   std::string filename;
   Vector3 scale;
 


### PR DESCRIPTION
Similar to #24, adds convex hull as a new type. `urdfdom` will be updated in an accompanying PR.