### PR TITLE
install pkgconfig file into correct path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if (NOT MSVC)
   set(PACKAGE_DESC "Unified Robot Description Format")
   set(pkg_conf_file "urdfdom_headers.pc")
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkgconfig/${pkg_conf_file}.in" "${CMAKE_BINARY_DIR}/${pkg_conf_file}" @ONLY)
-  install(FILES "${CMAKE_BINARY_DIR}/${pkg_conf_file}" DESTINATION lib/pkgconfig/ COMPONENT pkgconfig)
+  install(FILES "${CMAKE_BINARY_DIR}/${pkg_conf_file}" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/ COMPONENT pkgconfig)
 endif()
 
 # Add uninstall target


### PR DESCRIPTION
Unconditionally dropping things in /usr/lib isn't always a good idea.