### PR TITLE
Replace float compare to 0 with <= compare

### DIFF
--- a/urdf_model/include/urdf_model/pose.h
+++ b/urdf_model/include/urdf_model/pose.h
@@ -166,6 +166,18 @@ public:
 
   void clear() { this->x=this->y=this->z=0.0;this->w=1.0; }
 
+  /**
+   * \brief Normalize the elements of this quaternion
+   *
+   * Note: This function historically checked if the norm of the elements
+   * equaled 0 using a strict floating point equals (s == 0.0) to prevent a
+   * divide by zero error. This comparison will cause the compiler to issue a
+   * warning with '-Wfloat-equal'. Comparing against a small epsilon would
+   * likely be more ideal, but its choice may be application specific and could
+   * change behavior of legacy code if chosen poorly. Using <= handles the
+   * warning without changing the behavior of this function, even though it's
+   * less than ideal.
+   */
   void normalize()
   {
     const double squared_norm =

--- a/urdf_model/include/urdf_model/pose.h
+++ b/urdf_model/include/urdf_model/pose.h
@@ -166,18 +166,6 @@ public:
 
   void clear() { this->x=this->y=this->z=0.0;this->w=1.0; }
 
-  /**
-   * \brief Normalize the elements of this quaternion
-   *
-   * Note: This function historically checked if the norm of the elements
-   * equaled 0 using a strict floating point equals (s == 0.0) to prevent a
-   * divide by zero error. This comparison will cause the compiler to issue a
-   * warning with '-Wfloat-equal'. Comparing against a small epsilon would
-   * likely be more ideal, but its choice may be application specific and could
-   * change behavior of legacy code if chosen poorly. Using <= handles the
-   * warning without changing the behavior of this function, even though it's
-   * less than ideal.
-   */
   void normalize()
   {
     const double squared_norm =
@@ -186,6 +174,14 @@ public:
       this->z * this->z +
       this->w * this->w;
 
+    // Note: This function historically checked if the norm of the elements
+    // equaled 0 using a strict floating point equals (s == 0.0) to prevent a
+    // divide by zero error. This comparison will cause the compiler to issue a
+    // warning with `-Wfloat-equal`. Comparing against a small epsilon would
+    // likely be more ideal, but its choice may be application specific and
+    // could change behavior of legacy code if chosen poorly. Using `<=`
+    // silences the warning without changing the behavior of this function, even
+    // though there are no situations squared_norm can be strictly less than 0.
     if (squared_norm <= 0.0)
     {
       this->x = 0.0;

--- a/urdf_model/include/urdf_model/pose.h
+++ b/urdf_model/include/urdf_model/pose.h
@@ -168,11 +168,13 @@ public:
 
   void normalize()
   {
-    double s = sqrt(this->x * this->x +
-                    this->y * this->y +
-                    this->z * this->z +
-                    this->w * this->w);
-    if (s == 0.0)
+    const double squared_norm =
+      this->x * this->x +
+      this->y * this->y +
+      this->z * this->z +
+      this->w * this->w;
+
+    if (squared_norm <= 0.0)
     {
       this->x = 0.0;
       this->y = 0.0;
@@ -181,6 +183,7 @@ public:
     }
     else
     {
+      const double s = sqrt(squared_norm);
       this->x /= s;
       this->y /= s;
       this->z /= s;


### PR DESCRIPTION
A warning is issued when compiling with `-Wfloat-equal`, which I notice when compiling sdformat. This logic is just trying to prevent a divide-by-0. Instead of trying to choose a relevant epsilon for this older library, I just chose to compare the squared_norm with `<=` to avoid the warning and preserve the old behavior.

Signed-off-by: Stephen Brawner <brawner@gmail.com>