### PR TITLE
[foxy] Upgrade cmake minimum version to 2.8.12 (#67)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8.12 FATAL_ERROR )
 project (urdfdom_headers)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
We can fast-forward merge this change from `master` to `foxy`.