### PR TITLE
Install pkg-config .pc file also on Windows/MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,12 +54,10 @@ install(FILES
   DESTINATION ${CMAKE_CONFIG_INSTALL_DIR} COMPONENT cmake)
 
 # Make the package config file
-if (NOT MSVC)
-  set(PACKAGE_DESC "Unified Robot Description Format")
-  set(pkg_conf_file "urdfdom_headers.pc")
-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkgconfig/${pkg_conf_file}.in" "${CMAKE_BINARY_DIR}/${pkg_conf_file}" @ONLY)
-  install(FILES "${CMAKE_BINARY_DIR}/${pkg_conf_file}" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/ COMPONENT pkgconfig)
-endif()
+set(PACKAGE_DESC "Unified Robot Description Format")
+set(pkg_conf_file "urdfdom_headers.pc")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkgconfig/${pkg_conf_file}.in" "${CMAKE_BINARY_DIR}/${pkg_conf_file}" @ONLY)
+install(FILES "${CMAKE_BINARY_DIR}/${pkg_conf_file}" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/ COMPONENT pkgconfig)
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE


### PR DESCRIPTION
On Windows, both vcpkg and conda package managers explicitly support the use of pkg-config `.pc` files. Consuming this files is done either via CMake's `FindPkgConfig` module, or directly using `pkg-config` tool with the `--msvc-syntax` command line option (see https://gitlab.freedesktop.org/pkg-config/pkg-config/-/blob/master/README.win32).

For this reason, I do not think there is any reason for not installing `.pc`  files if the library is configured on Windows.