### PR TITLE
add package.xml file from ros2 release repository

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>urdfdom_headers</name>
+  <version>1.1.2</version>
+  <description>
+    C++ headers for URDF.
+  </description>
+  <maintainer email="steven@openrobotics.org">Steven! Ragnarök</maintainer>
+  <license>BSD</license>
+
+  <url type="website">http://ros.org/wiki/urdf</url>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <depend>console_bridge</depend>
+  <depend>tinyxml</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
My preferred solution for discussion in #82.

It seems weird that this is the only ROS package in the core that doesn't have a package.xml. 

I also have a personal agenda here because it is causing me some grief when I attempt to cross-compile and cross-package modules through a colcon extension I made.

Happy to make whatever changes you need to get this merged if you're interested.