### PR TITLE
Fix package.xml deps to use vendored packages

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,8 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <depend>console_bridge</depend>
-  <depend>tinyxml</depend>
+  <depend>console_bridge_vendor</depend>
+  <depend>tinyxml_vendor</depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
As the title says, this should fix problems introduced to build.ros2.org nightlies