### PR TITLE
Remove all dependencies from the package.xml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,6 @@
 urdfdom_headers
-===========
+===============
 
 The URDF (U-Robot Description Format) headers provides core data structure headers for URDF.
 
 For now, the details of the URDF specifications reside on http://ros.org/wiki/urdf
-  
-### Build Status
-[![Build Status](https://travis-ci.org/ros/urdfdom_headers.png)](https://travis-ci.org/ros/urdfdom_headers)
-
-### Using with ROS
-
-If you choose to check this repository out for use with ROS, be aware that the necessary ``package.xml`` is not 
-included in this repo but instead is added in during the ROS release process. To emulate this, pull the appropriate
-file into this repository using the following format. Be sure to replace the ALLCAPS words with the appropriate terms:
-
-```
-wget https://raw.github.com/ros-gbp/urdfdom_headers-release/debian/ROS_DISTRO/UBUNTU_DISTRO/urdfdom_headers/package.xml
-```
-
-For example:
-```
-wget https://raw.github.com/ros-gbp/urdfdom_headers-release/debian/hydro/precise/urdfdom_headers/package.xml
-```
-

--- a/package.xml
+++ b/package.xml
@@ -13,9 +13,6 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <depend>console_bridge_vendor</depend>
-  <depend>tinyxml_vendor</depend>
-
   <export>
     <build_type>cmake</build_type>
   </export>


### PR DESCRIPTION
This package does not have any header dependencies, so we don't need any of them here.

@sloretz @Blast545 @ahcorde This is follow-up from #85 and #87.  I *believe* it is correct, but double-check my logic here:

1.  This is a header-only package, so it doesn't need any dependencies in order to build itself.
2.  The headers don't depend on anything beyond the STL, so we don't need to export dependencies to downstream packages.

(if it turns out my logic above is wrong, then at the very least this should *not* depend on `tinyxml_vendor`, and should instead depend on `tinyxml2_vendor`)