### PR TITLE
Bump to 2.0.2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>urdfdom_headers</name>
-  <version>2.0.1</version>
+  <version>2.0.2</version>
   <description>
     C++ headers for URDF.
   </description>


### PR DESCRIPTION
This bumps the version to 2.0.2 in preparation for another release.

This is needed because in the 2.0.1 tag, the cmake version is still 2.0.0, so it is not possible for cmake to `find_package` that version (see https://github.com/ros/urdfdom/pull/235#issuecomment-3667565842). The change in #92 keeps the cmake version in sync with the package.xml, so this issue should be resolved.

Feel free to rebase-and-merge in order to have the simple "2.0.2" commit message.