### PR TITLE
Update lower, upper, effort, and velocity default joint limits

### DIFF
--- a/include/urdf_model/joint.h
+++ b/include/urdf_model/joint.h
@@ -77,10 +77,10 @@ public:
 
   void clear()
   {
-    lower = 0;
-    upper = 0;
-    effort = 0;
-    velocity = 0;
+    lower = -std::numeric_limits<double>::infinity();
+    upper = std::numeric_limits<double>::infinity();
+    effort = std::numeric_limits<double>::infinity();
+    velocity = std::numeric_limits<double>::infinity();
     acceleration = std::numeric_limits<double>::infinity();
     deceleration = std::numeric_limits<double>::infinity();
     jerk = std::numeric_limits<double>::infinity();

--- a/include/urdf_model/joint.h
+++ b/include/urdf_model/joint.h
@@ -77,8 +77,8 @@ public:
 
   void clear()
   {
-    lower = -std::numeric_limits<double>::quiet_NaN();
-    upper = std::numeric_limits<double>::quiet_NaN();
+    lower = -std::numeric_limits<double>::infinity();
+    upper = std::numeric_limits<double>::infinity();
     effort = std::numeric_limits<double>::infinity();
     velocity = std::numeric_limits<double>::infinity();
     acceleration = std::numeric_limits<double>::infinity();

--- a/include/urdf_model/joint.h
+++ b/include/urdf_model/joint.h
@@ -77,8 +77,8 @@ public:
 
   void clear()
   {
-    lower = -std::numeric_limits<double>::infinity();
-    upper = std::numeric_limits<double>::infinity();
+    lower = -std::numeric_limits<double>::quiet_NaN();
+    upper = std::numeric_limits<double>::quiet_NaN();
     effort = std::numeric_limits<double>::infinity();
     velocity = std::numeric_limits<double>::infinity();
     acceleration = std::numeric_limits<double>::infinity();


### PR DESCRIPTION
Changes from https://github.com/ros/urdfdom/pull/212#discussion_r2051130899 and https://github.com/ros/urdfdom_headers/pull/83#issuecomment-3694628855.
https://github.com/ros/urdfdom/pull/212 should be updated accordingly, or a new PR should be created to update the defaults of these limits.