### PR TITLE
Revert "cleanup declaration of ModelInterface's SharedPtrs"

### DIFF
--- a/include/urdf_model/types.h
+++ b/include/urdf_model/types.h
@@ -67,8 +67,6 @@ URDF_TYPEDEF_CLASS_POINTER(Mesh);
 URDF_TYPEDEF_CLASS_POINTER(Sphere);
 URDF_TYPEDEF_CLASS_POINTER(Visual);
 
-URDF_TYPEDEF_CLASS_POINTER(ModelInterface);
-
 // create *_pointer_cast functions in urdf namespace
 template<class T, class U>
 std::shared_ptr<T> const_pointer_cast(std::shared_ptr<U> const & r)

--- a/include/urdf_world/types.h
+++ b/include/urdf_world/types.h
@@ -37,7 +37,16 @@
 #ifndef URDF_WORLD_TYPES_H
 #define URDF_WORLD_TYPES_H
 
-#warning urdf_world/types.h is deprecated. Please use urdf_model/types.h instead.
-#include <urdf_model/types.h>
+#include <memory>
+
+
+namespace urdf{
+
+class ModelInterface;
+
+// typedef shared pointers
+typedef std::shared_ptr<ModelInterface> ModelInterfaceSharedPtr;
+
+}
 
 #endif

--- a/include/urdf_world/world.h
+++ b/include/urdf_world/world.h
@@ -74,9 +74,10 @@
 #include <vector>
 #include <map>
 
-#include "urdf_model/types.h"
+#include "urdf_model/model.h"
 #include "urdf_model/pose.h"
 #include "urdf_model/twist.h"
+#include "urdf_world/types.h"
 
 namespace urdf{
 
@@ -106,3 +107,4 @@ public:
 }
 
 #endif
+


### PR DESCRIPTION
Reverts ros/urdfdom_headers#33

I think this is one is breaking Windows

@scpeters and @rhaschke